### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Seeing JavaFX issues (e.g., https://github.com/JabRef/jabref/issues/9426 and https://github.com/JabRef/jabref/issues/10716), we should have a MWE project, which is this one. The project should have recent dependencies. Thus, adding dependabot here.