### PR TITLE
Add manual trigger

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -3,6 +3,7 @@ name: Update Gradle Wrapper
 on:
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   update-gradle-wrapper:


### PR DESCRIPTION
This repo has Gradle 8.5, but Gradle 8.6 should be the most recent release (https://gradle.org/releases/).

I don't know, why the action does not update. Need to test manually, therefore, the manual trigger.

Background: It seems, we need Gradle 8.6 for this repo (https://github.com/JabRef/jabref/issues/10716#issuecomment-2003041325).