### PR TITLE
Try to fix update

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions:
+  pull-requests: write
+
 jobs:
   update-gradle-wrapper:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The update workflow has errors - https://github.com/Siedlerchr/javafxreproducer/actions/runs/8655128025

    remote: Permission to Siedlerchr/javafxreproducer.git denied to github-actions[bot].
    fatal: unable to access 'https://github.com/Siedlerchr/javafxreproducer/': The requested URL returned error: 403

I think, this can be fixed by the `permissions` magic