### PR TITLE
Remove keepalive job from gradle.yml

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -39,11 +39,3 @@ jobs:
         name: javafxreproducer-${{ matrix.os }}
         path: build/distributions
         compression-level: 0
-  keepalive:
-    name: Keepalive
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: gautamkrishnar/keepalive-workflow@v2


### PR DESCRIPTION
In case https://github.com/Siedlerchr/javafxreproducer/pull/47 does not work, here is an important change.